### PR TITLE
Bump distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian11@sha256:c737fc29fc2556d3377d6a719a9842a500777fce35a7f1299acd569c73f65247
+FROM gcr.io/distroless/java17-debian11@sha256:672df6324b5e36527b201135c37c3ed14579b2eb9485a4f4e9ab526d466f671c
 
 COPY build/libs/app.jar /app/
 


### PR DESCRIPTION
Bump distroless SHA to 672df6324b5e36527b201135c37c3ed14579b2eb9485a4f4e9ab526d466f671c